### PR TITLE
Update post view tracking and API call for single post

### DIFF
--- a/backend/controllers/post/postController.js
+++ b/backend/controllers/post/postController.js
@@ -105,11 +105,13 @@ const postController = {
 
     //* Increment views count
     if (userId) {
-      if (!postFound.viewers.includes(userId)) {
-        postFound.viewers.push(userId);
-        postFound.viewsCount += 1;
-        await postFound.save();
-      }
+      await Post.findByIdAndUpdate(
+        postId,
+        {
+          $addToSet: { viewers: userId },
+        },
+        { new: true }
+      );
     }
 
     res.status(200).json({

--- a/frontend/src/APIservices/posts/postAPI.js
+++ b/frontend/src/APIservices/posts/postAPI.js
@@ -20,7 +20,9 @@ export const getAllPostsAPI = async (filters) => {
 
 //* Get Single Post API
 export const getSinglePostAPI = async (postId) => {
-  const response = await axios.get(`${BASE_URL}/${postId}`);
+  const response = await axios.get(`${BASE_URL}/${postId}`, {
+    withCredentials: true,
+  });
   return response.data;
 };
 

--- a/frontend/src/components/posts/PostDetails.jsx
+++ b/frontend/src/components/posts/PostDetails.jsx
@@ -150,7 +150,7 @@ const PostDetails = () => {
           {/* views icon */}
           <span className="flex items-center gap-1">
             <FaEye />
-            {postData?.post?.viewsCount || 0}
+            {postData?.post?.viewers?.length || 0}
           </span>
         </div>
         {/* follow icon */}


### PR DESCRIPTION
Refactored backend to use $addToSet for tracking unique post viewers and removed direct increment of viewsCount. Updated frontend API call for single post to include credentials, and changed PostDetails to display the number of viewers based on the viewers array length.